### PR TITLE
RuName (Redirect Url as name) support

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -107,6 +107,7 @@ function OAuth2Strategy(options, verify) {
   }
   this._trustProxy = options.proxy;
   this._passReqToCallback = options.passReqToCallback;
+  this._redirectUrlAsName = options.redirectUrlAsName ? options.redirectUrlAsName : false;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
 }
 
@@ -133,7 +134,7 @@ OAuth2Strategy.prototype.authenticate = function(req, options) {
   }
 
   var callbackURL = options.callbackURL || this._callbackURL;
-  if (callbackURL) {
+  if (callbackURL && !this._redirectUrlAsName) {
     var parsed = url.parse(callbackURL);
     if (!parsed.protocol) {
       // The callback URL is relative, resolve a fully qualified URL from the


### PR DESCRIPTION
Redirect URL as a name support for Ebay type application which uses RuName instead of fully qualified URL as callback url for Oauth

#83